### PR TITLE
Added headlight intensity configuration to Viewer

### DIFF
--- a/engine/src/viewer/viewer.js
+++ b/engine/src/viewer/viewer.js
@@ -20,6 +20,7 @@ Vizi.Viewer = function(param)
 	this.renderStatsUpdateInterval = (param.renderStatsUpdateInterval !== undefined) ? param.renderStatsUpdateInterval : 1000;
 	this.loopAnimations = (param.loopAnimations !== undefined) ? param.loopAnimations : false;
 	this.headlightOn = (param.headlight !== undefined) ? param.headlight : true;
+	this.headlightIntensity = param.headlightIntensity || Vizi.Viewer.DEFAULT_HEADLIGHT_INTENSITY;
 	this.firstPerson = (param.firstPerson !== undefined) ? param.firstPerson : false;
 	this.showGrid = (param.showGrid !== undefined) ? param.showGrid : false;
 	this.showBoundingBox = (param.showBoundingBox !== undefined) ? param.showBoundingBox : false;
@@ -211,12 +212,12 @@ Vizi.Viewer.prototype.replaceScene = function(data)
 			this.lightColors.push(data.lights[i].color.clone());
 		}
 		
-		this.controllerScript.headlight.intensity = len ? 0 : 1;
+		this.controllerScript.headlight.intensity = len ? 0 : this.headlightIntensity;
 		this.headlightOn = len <= 0;
 	}
 	else
 	{
-		this.controllerScript.headlight.intensity = 1;
+		this.controllerScript.headlight.intensity = this.headlightIntensity;
 		this.headlightOn = true;
 	}
 	
@@ -297,7 +298,7 @@ Vizi.Viewer.prototype.addToScene = function(data)
 	}
 	else if (!this.lights.length)
 	{
-		this.controllerScript.headlight.intensity = 1;
+		this.controllerScript.headlight.intensity = this.headlightIntensity;
 		this.headlightOn = true;
 	}
 	
@@ -459,8 +460,13 @@ Vizi.Viewer.prototype.setLoopAnimations = function(on)
 
 Vizi.Viewer.prototype.setHeadlightOn = function(on)
 {
-	this.controllerScript.headlight.intensity = on ? 1 : 0;
+	this.controllerScript.headlight.intensity = this.headlightIntensity ? this.headlightIntensity : 0;
 	this.headlightOn = on;
+}
+
+Vizi.Viewer.prototype.setHeadlightIntensity = function(intensity)
+{
+	this.controllerScript.headlight.intensity = intensity;
 }
 
 Vizi.Viewer.prototype.setGridOn = function(on)
@@ -677,3 +683,4 @@ Vizi.Viewer.DEFAULT_GRID_SIZE = 100;
 Vizi.Viewer.DEFAULT_GRID_STEP_SIZE = 1;
 Vizi.Viewer.GRID_COLOR = 0x202020;
 Vizi.Viewer.GRID_OPACITY = 0.2;
+Vizi.Viewer.DEFAULT_HEADLIGHT_INTENSITY = 1;


### PR DESCRIPTION
The default Viewer headlight's intensity can now be set as a param or by calling the Vizi.Viewer.setHeadlightIntensity(intensity) function. The default value of 1 wasn't bright enough for most of my models. It still defaults to 1 though.

If this pull request is merged, the final build files (vizi.js etc) need to be built again per your specs. When I build them, it looks like my version of closure library is adding additional comments to it or something compared to the existing vizi.js. Also I can't build the minified versions - I get an error about an unspecified file not being found (probably missing a dependency for that but not worth investigating at the moment).
